### PR TITLE
Revert "set active player to none when game is over"

### DIFF
--- a/BeatTheComputer/BeatTheComputer/Checkers/CheckersContext.cs
+++ b/BeatTheComputer/BeatTheComputer/Checkers/CheckersContext.cs
@@ -69,9 +69,6 @@ namespace BeatTheComputer.Checkers
                 moves++;
 
                 winner = board.currentWinner(activePlayer);
-                if (GameDecided) {
-                    activePlayer = Player.NONE;
-                }
             }
 
             return this;

--- a/BeatTheComputer/BeatTheComputer/ConnectFour/ConnectFourContext.cs
+++ b/BeatTheComputer/BeatTheComputer/ConnectFour/ConnectFourContext.cs
@@ -63,10 +63,6 @@ namespace BeatTheComputer.ConnectFour
                 if (moves >= 7) {
                     winner = board.currentWinner();
                 }
-
-                if (GameDecided) {
-                    activePlayer = Player.NONE;
-                }
             }
 
             return this;

--- a/BeatTheComputer/BeatTheComputer/GUI/GameController.cs
+++ b/BeatTheComputer/BeatTheComputer/GUI/GameController.cs
@@ -71,8 +71,8 @@ namespace BeatTheComputer.GUI
                 history[current].Context.applyAction(action);
                 history[current].LastAction = action;
                 updateViewMethod();
-                turn = history[current].Context.ActivePlayer;
                 if (!history[current].Context.GameDecided) {
+                    turn = history[current].Context.ActivePlayer;
                     tryComputerTurn();
                 }
             } else if (paused) {
@@ -124,7 +124,9 @@ namespace BeatTheComputer.GUI
                 interruptSource.Cancel();
                 pendingAction = null;
                 current++;
-                turn = history[current].Context.ActivePlayer;
+                if (!history[current].Context.GameDecided) {
+                    turn = history[current].Context.ActivePlayer;
+                }
                 interruptSource = new CancellationTokenSource();
                 updateViewMethod();
                 tryComputerTurn();

--- a/BeatTheComputer/BeatTheComputer/TicTacToe/TicTacToeContext.cs
+++ b/BeatTheComputer/BeatTheComputer/TicTacToe/TicTacToeContext.cs
@@ -51,10 +51,6 @@ namespace BeatTheComputer.TicTacToe
                 if (moves >= 5) {
                     winner = getWinner();
                 }
-
-                if (GameDecided) {
-                    activePlayer = Player.NONE;
-                }
             }
 
             return this;


### PR DESCRIPTION
introduces a bug as MCTS used active player to calculate score of a node - including for terminal nodes